### PR TITLE
Added a message to show why a command does not work at the time

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ client.on("message", (message) => {
   }
 
   if (message.content.startsWith("!play")) {
-    if (Poker.isQuestionRunning) return;
+    if (Poker.isQuestionRunning) return message.channel.send("There is already a question in progress.");
 
     const question = message.content.split(" ").splice(1).join(" ");
 
@@ -55,7 +55,7 @@ client.on("message", (message) => {
   }
 
   if (message.content.startsWith("!storypoints")) {
-    if (!Poker.isQuestionRunning) return;
+    if (!Poker.isQuestionRunning) return message.channel.send("You are currently not answering a question.");
 
     const storypoints = message.content.split(" ")[1];
 


### PR DESCRIPTION
Messages have been added to both '!play' and '!storypoints' to let the user know why they can not continue.

!play returns a message saying "There is already a question in progress."
!storypoints returns a message saying "You are currently not answering a question"

solves #10 

(sorry for the small mess up I made when trying to create the pull request, this is my first time using github like this)