### PR TITLE
fix #40: move entrypoint (index.js) into the root directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-require("dotenv").config({ path: "../.env" });
+require("dotenv").config();
 
-const { client } = require("./client");
+const { client } = require("./src/client");
 
 // distinguishing the different types of error
 // otherwhise we can use only one try/catch block and return a general error

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "private": false,
   "scripts": {
     "test": "jest --detectOpenHandles --forceExit",
-    "dev": "cd src && nodemon ./src/index.js",
-    "start": "cd src && node ./src/index.js",
+    "dev": "nodemon index.js",
+    "start": "node index.js",
     "lint": "npx eslint ./"
   },
   "dependencies": {


### PR DESCRIPTION
This moves the `index.js` file from the `src` folder into the root directory.