### PR TITLE
Refactor to add discordjs aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-DISCORD_SECRET=
-BOT_NAME="planning-poker-bot"

--- a/src/client.js
+++ b/src/client.js
@@ -31,8 +31,8 @@ const onMessage = (message, waitingSeconds = timeoutInSeconds) => {
 
   const args = message.content.slice(prefix.length).trim().split(/ +/);
   //allArgs is an object including arguments required by *any* command. This way, we can 
-  //execute commands on line 43 dynamically, instead of of switch/case and manual execution
-  //this makes the codebase easier to maintain and scale :)
+  //execute commands dynamically via command.execute(message, allArgs), instead of switch/case 
+  //and manual execution. This makes the codebase easier to maintain and scale :)
   const allArgs = { args, games, Poker, waitingSeconds };
   const commandName = args.shift().toLowerCase();
 

--- a/src/client.js
+++ b/src/client.js
@@ -10,6 +10,7 @@ client.commands = new Collection();
 
 const commandsPath = path.join(__dirname, "commands");
 const commandFiles = fs.readdirSync(commandsPath).filter((file) => file.endsWith(".js"));
+const prefix = '!';
 
 for (const file of commandFiles) {
   const command = require(`./commands/${file}`);
@@ -25,30 +26,20 @@ client.on("ready", () => {
 const timeoutInSeconds = 30 * 1000;
 
 const onMessage = (message, waitingSeconds = timeoutInSeconds) => {
-  if (message.author.username === process.env.BOT_NAME) return;
+  if (message.author.bot || !message.content.startsWith(prefix)) return;
 
-  const args = message.content.trim().split(/ +/);
+  const args = message.content.slice(prefix.length).trim().split(/ +/);
+
+  const allArgs = { args, games, Poker, waitingSeconds };
   const command = args.shift().toLowerCase();
 
-  switch (command) {
-    case "!start":
-      client.commands.get("start").execute(message, { args, games });
-      break;
-    case "!play":
-      client.commands.get("play").execute(message, { args, Poker, waitingSeconds });
-      break;
-    case "!sp":
-    case "!storypoints":
-      client.commands.get("storypoints").execute(message, { args, Poker });
-      break;
-    case "!end":
-      client.commands.get("end").execute(message, { args, Poker, games });
-      break;
-    case "!help":
-      client.commands.get("help").execute(message);
-      break;
-    default:
-      break;
+  if (!client.commands.has(command)) return;
+
+  try {
+    client.commands.get(command).execute(message, allArgs);
+  } catch (error) {
+    console.error(error);
+    message.reply('An error occured while trying to execute that command!');
   }
 
   if (message.channel.type === "dm" && Poker.isQuestionRunning) {

--- a/src/client.js
+++ b/src/client.js
@@ -27,7 +27,7 @@ const timeoutInSeconds = 30 * 1000;
 
 const onMessage = (message, waitingSeconds = timeoutInSeconds) => {
   //ignore the message if it's a message from the bot or it doesn't start with !
-  if (message.author.bot || !message.content.startsWith(prefix)) return;
+  if (message.author.bot) return;
 
   const args = message.content.slice(prefix.length).trim().split(/ +/);
   //allArgs is an object including arguments required by *any* command. This way, we can 

--- a/src/client.js
+++ b/src/client.js
@@ -26,17 +26,24 @@ client.on("ready", () => {
 const timeoutInSeconds = 30 * 1000;
 
 const onMessage = (message, waitingSeconds = timeoutInSeconds) => {
+  //ignore the message if it's a message from the bot or it doesn't start with !
   if (message.author.bot || !message.content.startsWith(prefix)) return;
 
   const args = message.content.slice(prefix.length).trim().split(/ +/);
-
+  //allArgs is an object including arguments required by *any* command. This way, we can 
+  //execute commands on line 43 dynamically, instead of of switch/case and manual execution
+  //this makes the codebase easier to maintain and scale :)
   const allArgs = { args, games, Poker, waitingSeconds };
-  const command = args.shift().toLowerCase();
+  const commandName = args.shift().toLowerCase();
 
-  if (!client.commands.has(command)) return;
+  //get the command based on the raw command name, or any one of its aliases
+  const command = client.commands.get(commandName) || client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));
 
+  if (!command) return;
+
+  //execute the command
   try {
-    client.commands.get(command).execute(message, allArgs);
+    command.execute(message, allArgs);
   } catch (error) {
     console.error(error);
     message.reply('An error occured while trying to execute that command!');

--- a/src/client.test.js
+++ b/src/client.test.js
@@ -2,61 +2,125 @@ const pokerGame = require("./client");
 
 jest.useFakeTimers();
 
-it("should print game start / welcome message", () => {
-  const mockedSend = jest.fn();
-  const message = {
-    author: { username: "" },
-    content: "!start",
-    channel: {
-      send: mockedSend,
-    },
-  };
-  pokerGame.onMessage(message, 0);
-  expect(mockedSend.mock.calls[0][0]).toMatch(/Welcome/);
-  expect(mockedSend.mock.calls[0][0]).toMatch(/Please/);
-  expect(mockedSend.mock.calls[0][0]).toMatch(/30 seconds/);
-  expect(mockedSend.mock.calls[0][0]).toMatch(/stop playing/);
+describe('Main tests', () => {
+  it("should print game start / welcome message", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!start",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Welcome/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Please/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/30 seconds/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/stop playing/);
+  });
+
+  it("should print first question message", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!play [QUESTION]",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/First question:/);
+  });
+
+  it("should print addition message", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!storypoints 3",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Added 3 to your question/);
+  });
+
+  it("should print finishing message", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!end",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Planning Poker finished/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(
+      /Here is an overview of your game:/
+    );
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Total Story Points: \d{1,}/);
+  });
 });
 
-it("should print first question message", () => {
-  const mockedSend = jest.fn();
-  const message = {
-    author: { username: "" },
-    content: "!play [QUESTION]",
-    channel: {
-      send: mockedSend,
-    },
-  };
-  pokerGame.onMessage(message, 0);
-  expect(mockedSend.mock.calls[0][0]).toMatch(/First question:/);
-});
+describe('aliases', () => {
+  it("should print game start / welcome message via alias", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!s",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Welcome/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Please/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/30 seconds/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/stop playing/);
+  });
 
-it("should print addition message", () => {
-  const mockedSend = jest.fn();
-  const message = {
-    author: { username: "" },
-    content: "!storypoints 3",
-    channel: {
-      send: mockedSend,
-    },
-  };
-  pokerGame.onMessage(message, 0);
-  expect(mockedSend.mock.calls[0][0]).toMatch(/Added 3 to your question/);
-});
+  it("should print first question message", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!p [QUESTION]",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/First question:/);
+  });
 
-it("should print finishing message", () => {
-  const mockedSend = jest.fn();
-  const message = {
-    author: { username: "" },
-    content: "!end",
-    channel: {
-      send: mockedSend,
-    },
-  };
-  pokerGame.onMessage(message, 0);
-  expect(mockedSend.mock.calls[0][0]).toMatch(/Planning Poker finished/);
-  expect(mockedSend.mock.calls[0][0]).toMatch(
-    /Here is an overview of your game:/
-  );
-  expect(mockedSend.mock.calls[0][0]).toMatch(/Total Story Points: \d{1,}/);
-});
+  it("should print addition message via storypoints alias", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!sp 10",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Added 10 to your question/);
+  });
+
+  it("should print finishing message", () => {
+    const mockedSend = jest.fn();
+    const message = {
+      author: { username: "" },
+      content: "!end",
+      channel: {
+        send: mockedSend,
+      },
+    };
+    pokerGame.onMessage(message, 0);
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Planning Poker finished/);
+    expect(mockedSend.mock.calls[0][0]).toMatch(
+      /Here is an overview of your game:/
+    );
+    expect(mockedSend.mock.calls[0][0]).toMatch(/Total Story Points: \d{1,}/);
+  });
+})
+

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,6 +1,7 @@
 module.exports = {
   name: "help",
   description: "help command",
+  aliases: ['/?', 'h'],
   execute(message) {
     message.channel.send(
       [

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -2,6 +2,7 @@
 module.exports = {
   name: "play",
   description: "play command",
+  aliases: ['p', 'go'],
   execute(message, args) {
     const { Poker } = args;
 

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -2,6 +2,7 @@
 module.exports = {
   name: "start",
   description: "start command",
+  aliases: ['s', 'st', 'strt'],
   execute(message, args) {
     const { games } = args;
 

--- a/src/commands/storypoints.js
+++ b/src/commands/storypoints.js
@@ -2,6 +2,7 @@
 module.exports = {
   name: "storypoints",
   description: "story points command",
+  aliases: ['sp', 'storyp', 'stp'],
   execute(message, args) {
     const { Poker } = args;
     if (!Poker.isQuestionRunning)


### PR DESCRIPTION
Refactored the command execution logic to now be able to use command aliases. 

The onMessage method now dynamically determines the command based on the raw command name, or any one of its aliases. Using an instance of the determined command, it's able to dynamically execute any of the commands using the allArgs object. This is easier to maintain and scale than a switch/case and manual execution. 

The aliases are set in each command file, with 'aliases' as the property name and an array of strings as the value (i.e. aliases = ['sp', 'stp'] as a property in the commands/storypoints.js file). To add/remove aliases for any commands, just change the array of strings to reflect which aliases you'd like.

I added alias tests in the 'aliases' describe block, and moved the existing tests into a 'Main tests' describe block. I ran all tests with npm test and they all pass. I did some manual testing and it seemed to work the same as before, and you may use aliases now for the commands. Feel free to do some more internal testing and let me know if I caused any issues. 