### PR TITLE
Feat: Run bot in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+FROM node:20-alpine AS production
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci --only=production
+
+COPY --from=build /app/dist ./dist
+
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": false,
   "scripts": {
     "test": "jest --detectOpenHandles --forceExit",
+    "build": "tsc",
     "start": "tsc && node dist/index.js",
     "lint": "npx eslint ./"
   },


### PR DESCRIPTION
This PR relates to issue https://github.com/Fubinator/planning-poker-discord-bot/issues/91

Creates dockerfile to run bot on a docker container